### PR TITLE
Signed-off-by: ffrances <ffrances@pontos-deb.gaea>

### DIFF
--- a/company-c-headers.el
+++ b/company-c-headers.el
@@ -41,6 +41,7 @@
 
 (require 'company)
 (require 'rx)
+(require 'cl)
 (require 'cl-lib)
 
 (defgroup company-c-headers nil
@@ -143,7 +144,7 @@ Filters on the appropriate regex for the current major mode."
                     (setq next nil)
                     tmp)))
       )
-    candidates
+    (remove-duplicates candidates :test 'equal)
     ))
 
 (defun company-c-headers--meta (candidate)

--- a/test/company-c-headers-test.el
+++ b/test/company-c-headers-test.el
@@ -128,6 +128,30 @@
     (should (equal (company-c-headers 'candidates "<sub/") '("<sub/sub.h")))
     )))
 
+(ert-deftest subdir-candidates-path-system-duplicates ()
+  "Test that duplicates proposal are removed system paths."
+
+  (with-test-headers
+   tmpdir '("first.h" "second.h")
+
+   (with-test-c-buffer
+    (setq company-c-headers-path-system (list tmpdir tmpdir))
+    (setq company-c-headers-path-user (list "foo" "bar"))
+    (should (equal (company-c-headers 'candidates "\"firs") '("\"first.h")))
+    )))
+
+(ert-deftest subdir-candidates-path-user-duplicates ()
+  "Test that duplicates proposal are removed when present user paths."
+  
+  (with-test-headers
+   tmpdir '("first.h" "second.h")
+
+   (with-test-c-buffer
+    (setq company-c-headers-path-system (list "foo" "bar"))
+    (setq company-c-headers-path-user (list tmpdir tmpdir))
+    (should (equal (company-c-headers 'candidates "\"firs") '("\"first.h")))
+    )))
+
 (ert-deftest path-bound-to-function ()
   "Tests that include paths can be provided by a function"
 


### PR DESCRIPTION
remove duplicates in headers proposition.
can be reproduced by setting company-c-headers-path-user with same directory twice.