### PR TITLE
Fix issue #27

### DIFF
--- a/company-c-headers.el
+++ b/company-c-headers.el
@@ -1,3 +1,4 @@
+
 ;;; company-c-headers.el --- Company mode backend for C/C++ header files  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014 Alastair Rankine
@@ -181,10 +182,14 @@ Filters on the appropriate regex for the current major mode."
              (setq this-command 'self-insert-command)
            ;; It's not a directory, add a terminating delimiter.
            ;; If pre-existing terminating delimiter already exists,
-           ;; move cursor to end of line.
-           (pcase (aref matched 0)
-             (?\" (if (looking-at "\"") (end-of-line) (insert "\"")))
-             (?<  (if (looking-at ">") (end-of-line) (insert ">"))))))))
+           ;; move cursor to end of line, ignoring white-space.
+	   (pcase (aref matched 0)
+             (?\" (if (looking-at "[ \t]*\"")
+                      (goto-char (match-end 0))
+                    (insert "\"")))
+             (?<  (if (looking-at "[ \t]*>")
+                      (goto-char (match-end 0))
+                    (insert ">"))))))))
     ))
 
 (provide 'company-c-headers)

--- a/company-c-headers.el
+++ b/company-c-headers.el
@@ -1,4 +1,3 @@
-
 ;;; company-c-headers.el --- Company mode backend for C/C++ header files  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014 Alastair Rankine
@@ -184,11 +183,9 @@ Filters on the appropriate regex for the current major mode."
            ;; If pre-existing terminating delimiter already exists,
            ;; move cursor to end of line, ignoring white-space.
 	   (pcase (aref matched 0)
-             (?\" (if (looking-at "[ \t]*\"")
-                      (goto-char (match-end 0))
+             (?\" (if (looking-at "[ \t]*\"") (goto-char (match-end 0))
                     (insert "\"")))
-             (?<  (if (looking-at "[ \t]*>")
-                      (goto-char (match-end 0))
+             (?<  (if (looking-at "[ \t]*>")  (goto-char (match-end 0))
                     (insert ">"))))))))
     ))
 

--- a/test/company-c-headers-test.el
+++ b/test/company-c-headers-test.el
@@ -230,4 +230,23 @@ If terminating > already exist, don't add the >."
      (should (looking-back expected))
      )))
 
+(ert-deftest post-completion-skips-existing-quote-with-spaces ()
+  "Skip an existing quote even if there is whitespace."
+  (with-test-c-buffer
+    (insert "#include \"stdio.h")
+    (save-excursion (insert "  \""))
+    (company-c-headers 'post-completion "\"stdio.h")
+    (should (equal (buffer-string) "#include \"stdio.h  \""))
+    (should (equal (char-before) ?\"))))
+
+
+(ert-deftest post-completion-skips-existing-bracket-with-spaces ()
+  "Skip an existing bracket even if there is whitespace."
+  (with-test-c-buffer
+    (insert "#include <stdio.h")
+    (save-excursion (insert "  >"))
+    (company-c-headers 'post-completion "<stdio.h")
+    (should (equal (buffer-string) "#include <stdio.h  >"))
+    (should (equal (char-before) ?>))))
+
 ;;; company-c-headers-test.el ends here


### PR DESCRIPTION
Fix for issue #27.
Simply changed the way a closing `"` or `>` is detected during `post-completion`.
Now we match a more robust regex to ignore white-space between point and closing quotes.
We also move cursor to the closing parens instead of `end-of-line`.

Here's a gif showing the changes (and the problem itself):
<img width="480" height="270" alt="company" src="https://github.com/user-attachments/assets/8835c56e-47c8-410a-9bb4-3733587b744f" />
